### PR TITLE
Fixed max length of DATNAME and remove some warnings

### DIFF
--- a/CakesROPSpider/Makefile
+++ b/CakesROPSpider/Makefile
@@ -10,7 +10,7 @@ INCLUDES=-I../include
 DEFINES=-DDATNAME='"$(DATNAME)"'
 
 ARCH=-march=armv6k -mtune=mpcore -mlittle-endian
-CFLAGS=-fshort-wchar -fomit-frame-pointer -ffast-math -std=gnu99 -Os -ffunction-sections -g -mword-relocations $(ARCH) $(INCLUDES) $(DEFINES)
+CFLAGS=-fshort-wchar -fomit-frame-pointer -ffast-math -std=gnu99 -Werror -Os -ffunction-sections -g -mword-relocations $(ARCH) $(INCLUDES) $(DEFINES)
 LDFLAGS=-nostartfiles --specs=crs.specs -Wl,-gc-sections $(ARCH)
 OBJCOPY=arm-none-eabi-objcopy
 OCFLAGS=-R .compat

--- a/CakesROPSpider/src/mkhax.c
+++ b/CakesROPSpider/src/mkhax.c
@@ -90,13 +90,13 @@ void do_gshax_copy(void *dst, const void *src, unsigned int len)
 
 	do
 	{
-		compat.app.memcpy(0x18401000, 0x18401000, 0x10000);
-		compat.app.GSPGPU_FlushDataCache(src, len);
+		compat.app.memcpy((void*)0x18401000, (void*)0x18401000, 0x10000);
+		compat.app.GSPGPU_FlushDataCache((void*)src, len);
 		// src always 0x18402000
 		compat.app.GX_SetTextureCopy(src, dst, len, 0, 0, 0, 0, 8);
-		compat.app.GSPGPU_FlushDataCache(0x18401000, 16);
-		compat.app.GX_SetTextureCopy(dst, 0x18401000, 0x40, 0, 0, 0, 0, 8);
-		compat.app.memcpy(0x18401000, 0x18401000, 0x10000);
+		compat.app.GSPGPU_FlushDataCache((void*)0x18401000, 16);
+		compat.app.GX_SetTextureCopy(dst, (void*)0x18401000, 0x40, 0, 0, 0, 0, 8);
+		compat.app.memcpy((void*)0x18401000, (void*)0x18401000, 0x10000);
 	}while(--i > 0);
 }
 
@@ -129,8 +129,8 @@ void arm11_kernel_exploit_setup(void)
 	compat.app.svcControlMemory(&mem_hax_mem, 0, 0, 0x6000, 0x10003, 1 | 2);
 
 	void* tmp_addr;
-	compat.app.svcControlMemory(&tmp_addr, mem_hax_mem + 0x4000, 0, 0x1000, 1, 0); // free page
-	compat.app.svcControlMemory(&tmp_addr, mem_hax_mem + 0x1000, 0, 0x2000, 1, 0); // free page
+	compat.app.svcControlMemory(&tmp_addr, (int)mem_hax_mem + 0x4000, 0, 0x1000, 1, 0); // free page
+	compat.app.svcControlMemory(&tmp_addr, (int)mem_hax_mem + 0x1000, 0, 0x2000, 1, 0); // free page
 
 	unsigned int saved_heap_3[8];
 	do_gshax_copy(arm11_buffer, mem_hax_mem + 0x1000, 0x20u);
@@ -140,8 +140,8 @@ void arm11_kernel_exploit_setup(void)
 	do_gshax_copy(arm11_buffer, mem_hax_mem + 0x4000, 0x20u);
 	compat.app.memcpy(saved_heap_2, arm11_buffer, sizeof(saved_heap_2));
 
-	compat.app.svcControlMemory(&tmp_addr, mem_hax_mem + 0x1000, 0, 0x2000, 0x10003, 1 | 2);
-	compat.app.svcControlMemory(&tmp_addr, mem_hax_mem + 0x2000, 0, 0x1000, 1, 0); // free page
+	compat.app.svcControlMemory(&tmp_addr, (int)mem_hax_mem + 0x1000, 0, 0x2000, 0x10003, 1 | 2);
+	compat.app.svcControlMemory(&tmp_addr, (int)mem_hax_mem + 0x2000, 0, 0x1000, 1, 0); // free page
 
 	do_gshax_copy(arm11_buffer, mem_hax_mem + 0x2000, 0x20u);
 
@@ -157,7 +157,7 @@ void arm11_kernel_exploit_setup(void)
 	do_gshax_copy(mem_hax_mem + 0x2000, arm11_buffer, 0x10u);
 
 	// Trigger write to kernel
-	compat.app.svcControlMemory(&tmp_addr, mem_hax_mem + 0x1000, 0, 0x1000, 1, 0);
+	compat.app.svcControlMemory(&tmp_addr, (int)mem_hax_mem + 0x1000, 0, 0x1000, 1, 0);
 
 	compat.app.memcpy(arm11_buffer, saved_heap_3, sizeof(saved_heap_3));
 	do_gshax_copy(mem_hax_mem + 0x1000, arm11_buffer, 0x20u);
@@ -306,7 +306,7 @@ void patch_srv_access()
 
 	// PID patching and unpatching idea: service-patch (archshift and Yifan Lu)
 	// Set pid to 0
-	arm11_kernel_exploit_exec(patch_kernel);
+	arm11_kernel_exploit_exec((void*)patch_kernel);
 
 	// Reinit srv
 	if(reinit_srv() != 0)
@@ -320,6 +320,6 @@ void patch_srv_access()
 		"mov r12, %[target_pid]\t\n"
 		::[target_pid] "r" (old_pid)
 	);
-	arm11_kernel_exploit_exec(unpatch_pid);
+	arm11_kernel_exploit_exec((void*)unpatch_pid);
 }
 

--- a/CakesROPSpider/src/nvram.c
+++ b/CakesROPSpider/src/nvram.c
@@ -89,7 +89,7 @@ void UserSettingsCRC(void *buffer)
 // Apply zoogie patches
 int ApplyPatch(const u8 *patchBuf, u8 *work, u32 sel)
 {
-	const wchar_t cakes[PAYLOAD_FNAME_LEN / 2] = L"YS:/" DATNAME;
+	const wchar_t cakes[PAYLOAD_FNAME_LEN / 2] = L"YS:/" DATNAME "\0";
 	u32 magic = *(u32 *)(patchBuf);
 	if(magic != 0x524f5050)
 		return -1;
@@ -112,15 +112,14 @@ int ApplyPatch(const u8 *patchBuf, u8 *work, u32 sel)
 	if(compat.app.IFile_Open(&file, L"dmc:/ropCustom.txt", FILE_R) == 0)
 	{
 		const u32 maxPathLen = PAYLOAD_FNAME_LEN / 2;
-		const u32 maxFnameLen = maxPathLen - 5;
 
 		u8 *custName = (u8 *)(0x18410000 + 0x200);
-		_memset(custName, 0, PAYLOAD_FNAME_LEN);
+		_memset(custName, 0, maxPathLen);
 		_memcpy(custName, "YS:/", 4);
 
 		unsigned int read;
-		compat.app.IFile_Read(&file, &read, custName + 4, maxFnameLen);
-		for(u32 i = 0; i < maxPathLen; i++)
+		compat.app.IFile_Read(&file, &read, custName + 4, maxPathLen - 4 - 1/*reserve 1 byte for \0*/);
+		for(u32 i = 0; i < maxPathLen - 1; i++)
 		{
 			name[i * 2 + 1] = 0;
 			if(custName[i] == '\n' || custName[i] == '\r' || custName[i] == 0)

--- a/CakesROPSpider/src/nvram.c
+++ b/CakesROPSpider/src/nvram.c
@@ -8,7 +8,7 @@
 #include "patches.h"
 #include "ctru.h"
 
-#define PAYLOAD_FNAME_LEN 0x30
+#define PAYLOAD_FNAME_LEN 0x34
 
 typedef struct index_s
 {
@@ -89,7 +89,7 @@ void UserSettingsCRC(void *buffer)
 // Apply zoogie patches
 int ApplyPatch(const u8 *patchBuf, u8 *work, u32 sel)
 {
-	const wchar_t cakes[] = L"YS:/" DATNAME;
+	const wchar_t cakes[PAYLOAD_FNAME_LEN / 2] = L"YS:/" DATNAME;
 	u32 magic = *(u32 *)(patchBuf);
 	if(magic != 0x524f5050)
 		return -1;

--- a/CakesROPSpider/src/nvram.c
+++ b/CakesROPSpider/src/nvram.c
@@ -112,7 +112,7 @@ int ApplyPatch(const u8 *patchBuf, u8 *work, u32 sel)
 	if(compat.app.IFile_Open(&file, L"dmc:/ropCustom.txt", FILE_R) == 0)
 	{
 		const u32 maxPathLen = PAYLOAD_FNAME_LEN / 2;
-		const u32 maxFnameLen = maxPathLen - 4;
+		const u32 maxFnameLen = maxPathLen - 5;
 
 		u8 *custName = (u8 *)(0x18410000 + 0x200);
 		_memset(custName, 0, PAYLOAD_FNAME_LEN);

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ GAME_SUBTITLE2 := http://devitpro.org
 #---------------------------------------------------------------------------------
 ARCH := -marm -mthumb-interwork -march=armv5te -mtune=arm946e-s
 
-CFLAGS   := -Wno-multichar -g -Wall -O3\
+CFLAGS   := -Wno-multichar -g -Wall -Werror -O3\
             $(ARCH) $(INCLUDE) -DARM9 -DDATNAME='"$(DATNAME)"' -DDISPNAME='"$(DISPNAME)"'
 CXXFLAGS := $(CFLAGS) -fno-rtti -fno-exceptions -O3
 ASFLAGS  := -g $(ARCH)

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -13,7 +13,7 @@ u8 workbuffer[1024] ALIGN(32);
 #define SCREEN_COLS 32
 #define ITEMS_PER_SCREEN 10
 #define ITEMS_START_ROW 12
-#define MAX_DATNAME_LEN 24
+#define MAX_DATNAME_LEN 26
 
 using namespace std;
 
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
 	int patchfile = 0;
 	int header;
 	rawDataOffset=0;
-	char datName[]="YS:/" DATNAME;
+	char datName[MAX_DATNAME_LEN]="YS:/" DATNAME;
 	char custom[6][35];
 
 	aread(&header,1,4,patchfile);
@@ -261,7 +261,8 @@ int main(int argc, char **argv) {
 
 	if (fwSelected < (int)patches.size()) {
 		for(int i = 0;i < MAX_DATNAME_LEN * 2;i += 2){
-			*(workbuffer + 0x11C + i) = datName[i / 2];
+			char c = datName[i / 2];
+			*(workbuffer + 0x11C + i) = c;
 			*(workbuffer + 0x11C + i + 1) = 0;
 		}
 	} else {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -261,8 +261,7 @@ int main(int argc, char **argv) {
 
 	if (fwSelected < (int)patches.size()) {
 		for(int i = 0;i < MAX_DATNAME_LEN * 2;i += 2){
-			char c = datName[i / 2];
-			*(workbuffer + 0x11C + i) = c;
+			*(workbuffer + 0x11C + i) = datName[i / 2];
 			*(workbuffer + 0x11C + i + 1) = 0;
 		}
 	} else {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
 	int header;
 	rawDataOffset=0;
 	char datName[MAX_DATNAME_LEN]="YS:/" DATNAME;
-	char custom[6][35];
+	char custom[6][MAX_DATNAME_LEN-4]={};
 
 	aread(&header,1,4,patchfile);
 
@@ -285,14 +285,15 @@ int main(int argc, char **argv) {
 		}
 		
 		for(i=0;i<customLinesTotal;i++){
-			fgets(custom[i],30,text);
-			if(!custom[i] || (custom[i][0] < 0x21) )break;
+			fgets(custom[i],MAX_DATNAME_LEN-4,text);
+			if(custom[i][0] < 0x21)break;
 			
-			for(int j=0; j < 30 ;j++){  //strip newline junk
-				if(custom[i][j]==0x0D || custom[i][j]==0x0A)
-					custom[i][j]=0;	
+			int j;
+			for(j=0; j < MAX_DATNAME_LEN-5; j++){  //strip newline junk
+				if(custom[i][j]==0x0D || custom[i][j]==0x0A || custom[i][j] == 0)
+					break;
 			}
-			custom[i][25]=0;    //make damn sure it terminates
+			custom[i][j]=0;    //make damn sure it terminates
 		}
 		if(i==0){
 			iprintf("      ropCustom.txt read error\n");

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
 	int patchfile = 0;
 	int header;
 	rawDataOffset=0;
-	char datName[MAX_DATNAME_LEN]="YS:/" DATNAME;
+	char datName[MAX_DATNAME_LEN]="YS:/" DATNAME "\0";
 	char custom[6][MAX_DATNAME_LEN-4]={};
 
 	aread(&header,1,4,patchfile);


### PR DESCRIPTION
As of DATNAME offset is 0x11C, and next patch is located at 0x150, there are 0x34 bytes for DATNAME, so I increase the max length of DATNAME to 0x34/2 bytes
